### PR TITLE
[BB-1038] query user and service accounts from `/users`

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -48,7 +48,7 @@ func NewClient(ctx context.Context, apiBaseURL, apiAccessID, apiAccessKey string
 
 // GetUsers retrieves user accounts (and service accounts when specified) from the API.
 func (c *Client) getUsers(ctx context.Context, pageToken *string, includeServiceAccounts bool) (
-	[]*AccountResponse,
+	[]*Account,
 	*string,
 	*v2.RateLimitDescription,
 	error,
@@ -58,7 +58,7 @@ func (c *Client) getUsers(ctx context.Context, pageToken *string, includeService
 	pathParameters := map[string]string{"apiVersion": apiVersion}
 	queryParams := map[string]string{"includeServiceAccounts": fmt.Sprintf("%t", includeServiceAccounts)}
 
-	var response ApiResponse[AccountResponse]
+	var response ApiResponse[Account]
 
 	pageSize := uint(resourcePageSize)
 	url, err := c.constructURL(path, pathParameters, queryParams, pageToken, &pageSize)
@@ -172,7 +172,7 @@ func (c *Client) removeRoleFromUser(ctx context.Context, roleId string, userId s
 }
 
 func (c *Client) getUserByID(ctx context.Context, userId string) (
-	*AccountResponse,
+	*Account,
 	*v2.RateLimitDescription,
 	error,
 ) {
@@ -185,7 +185,7 @@ func (c *Client) getUserByID(ctx context.Context, userId string) (
 		return nil, nil, fmt.Errorf("error generating get user by ID URL: %w", err)
 	}
 
-	var response AccountResponse
+	var response Account
 	rateLimit, err := c.get(ctx, url, &response)
 	if err != nil {
 		return nil, rateLimit, fmt.Errorf("error executing request: %w", err)
@@ -195,7 +195,7 @@ func (c *Client) getUserByID(ctx context.Context, userId string) (
 }
 
 func (c *Client) createUser(ctx context.Context, userRequest UserRequest) (
-	*AccountResponse,
+	*Account,
 	*v2.RateLimitDescription,
 	error,
 ) {
@@ -215,7 +215,7 @@ func (c *Client) createUser(ctx context.Context, userRequest UserRequest) (
 		"roleIds":   userRequest.RoleIDs,
 	}
 
-	var response AccountResponse
+	var response Account
 	rateLimit, err := c.post(ctx, url, &response, payload)
 	if err != nil {
 		return nil, rateLimit, fmt.Errorf("error executing request: %w", err)

--- a/pkg/client/client_interface.go
+++ b/pkg/client/client_interface.go
@@ -8,9 +8,9 @@ import (
 
 // ClientService defines the interface for client operations.
 type ClientService interface {
-	GetUserByID(ctx context.Context, userId string) (*AccountResponse, *v2.RateLimitDescription, error)
-	GetUsers(ctx context.Context, pageToken *string, includeServiceAccounts bool) ([]*AccountResponse, *string, *v2.RateLimitDescription, error)
-	CreateUser(ctx context.Context, userRequest UserRequest) (*AccountResponse, *v2.RateLimitDescription, error)
+	GetUserByID(ctx context.Context, userId string) (*Account, *v2.RateLimitDescription, error)
+	GetUsers(ctx context.Context, pageToken *string, includeServiceAccounts bool) ([]*Account, *string, *v2.RateLimitDescription, error)
+	CreateUser(ctx context.Context, userRequest UserRequest) (*Account, *v2.RateLimitDescription, error)
 	DeleteUser(ctx context.Context, userId string) (*v2.RateLimitDescription, error)
 	GetRoles(ctx context.Context, pageToken *string) ([]*RoleResponse, *string, *v2.RateLimitDescription, error)
 	GetRole(ctx context.Context, roleId string) (*RoleResponse, *v2.RateLimitDescription, error)
@@ -27,11 +27,11 @@ func NewClientService(client *Client) ClientService {
 	return &ClientServiceImpl{client: *client}
 }
 
-func (s *ClientServiceImpl) GetUserByID(ctx context.Context, userId string) (*AccountResponse, *v2.RateLimitDescription, error) {
+func (s *ClientServiceImpl) GetUserByID(ctx context.Context, userId string) (*Account, *v2.RateLimitDescription, error) {
 	return s.client.getUserByID(ctx, userId)
 }
 
-func (s *ClientServiceImpl) CreateUser(ctx context.Context, userRequest UserRequest) (*AccountResponse, *v2.RateLimitDescription, error) {
+func (s *ClientServiceImpl) CreateUser(ctx context.Context, userRequest UserRequest) (*Account, *v2.RateLimitDescription, error) {
 	return s.client.createUser(ctx, userRequest)
 }
 
@@ -39,7 +39,7 @@ func (s *ClientServiceImpl) DeleteUser(ctx context.Context, userId string) (*v2.
 	return s.client.deleteUser(ctx, userId)
 }
 
-func (s *ClientServiceImpl) GetUsers(ctx context.Context, pageToken *string, includeServiceAccounts bool) ([]*AccountResponse, *string, *v2.RateLimitDescription, error) {
+func (s *ClientServiceImpl) GetUsers(ctx context.Context, pageToken *string, includeServiceAccounts bool) ([]*Account, *string, *v2.RateLimitDescription, error) {
 	return s.client.getUsers(ctx, pageToken, includeServiceAccounts)
 }
 

--- a/pkg/client/client_mock.go
+++ b/pkg/client/client_mock.go
@@ -7,21 +7,21 @@ import (
 )
 
 type MockClientService struct {
-	GetUserByIDFunc        func(ctx context.Context, userId string) (*AccountResponse, *v2.RateLimitDescription, error)
-	CreateUserFunc         func(ctx context.Context, userRequest UserRequest) (*AccountResponse, *v2.RateLimitDescription, error)
+	GetUserByIDFunc        func(ctx context.Context, userId string) (*Account, *v2.RateLimitDescription, error)
+	CreateUserFunc         func(ctx context.Context, userRequest UserRequest) (*Account, *v2.RateLimitDescription, error)
 	DeleteUserFunc         func(ctx context.Context, userId string) (*v2.RateLimitDescription, error)
-	GetUsersFunc           func(ctx context.Context, pageToken *string, includeServiceAccounts bool) ([]*AccountResponse, *string, *v2.RateLimitDescription, error)
+	GetUsersFunc           func(ctx context.Context, pageToken *string, includeServiceAccounts bool) ([]*Account, *string, *v2.RateLimitDescription, error)
 	GetRolesFunc           func(ctx context.Context, pageToken *string) ([]*RoleResponse, *string, *v2.RateLimitDescription, error)
 	GetRoleFunc            func(ctx context.Context, roleId string) (*RoleResponse, *v2.RateLimitDescription, error)
 	AssignRoleToUserFunc   func(ctx context.Context, roleId string, userId string) (*RoleResponse, *v2.RateLimitDescription, error)
 	RemoveRoleFromUserFunc func(ctx context.Context, roleId string, userId string) (*v2.RateLimitDescription, error)
 }
 
-func (m *MockClientService) GetUserByID(ctx context.Context, userId string) (*AccountResponse, *v2.RateLimitDescription, error) {
+func (m *MockClientService) GetUserByID(ctx context.Context, userId string) (*Account, *v2.RateLimitDescription, error) {
 	return m.GetUserByIDFunc(ctx, userId)
 }
 
-func (m *MockClientService) CreateUser(ctx context.Context, userRequest UserRequest) (*AccountResponse, *v2.RateLimitDescription, error) {
+func (m *MockClientService) CreateUser(ctx context.Context, userRequest UserRequest) (*Account, *v2.RateLimitDescription, error) {
 	return m.CreateUserFunc(ctx, userRequest)
 }
 
@@ -29,7 +29,7 @@ func (m *MockClientService) DeleteUser(ctx context.Context, userId string) (*v2.
 	return m.DeleteUserFunc(ctx, userId)
 }
 
-func (m *MockClientService) GetUsers(ctx context.Context, pageToken *string, includeServiceAccounts bool) ([]*AccountResponse, *string, *v2.RateLimitDescription, error) {
+func (m *MockClientService) GetUsers(ctx context.Context, pageToken *string, includeServiceAccounts bool) ([]*Account, *string, *v2.RateLimitDescription, error) {
 	return m.GetUsersFunc(ctx, pageToken, includeServiceAccounts)
 }
 

--- a/pkg/client/models.go
+++ b/pkg/client/models.go
@@ -27,10 +27,15 @@ type ApiResponse[T any] struct {
 	Next *string `json:"next,omitempty"`
 }
 
-// AccountResponse can represent a user or service account.
-type AccountResponse struct {
+// Account can represent a user or service account.
+// Used for client requests and responses.
+type Account struct {
 	ID    string `json:"id"`
 	Email string `json:"email"`
+	// Represents the first name for a user or the "full" name for a service account.
+	FirstName string `json:"firstName"`
+	// Only used for user accounts.
+	LastName string `json:"lastName"`
 	// Creation timestamp in UTC in RFC3339 format <date-time> (YYYY-MM-DDTHH:MM:SSZ).
 	// https://datatracker.ietf.org/doc/html/rfc3339 .
 	CreatedAt time.Time `json:"createdAt"`
@@ -42,16 +47,10 @@ type AccountResponse struct {
 	ModifiedBy string   `json:"modifiedBy"`
 	RoleIDs    []string `json:"roleIds"`
 	IsActive   *bool    `json:"isActive,omitempty"`
-
-	// For both user and service accounts:
-	FirstName string `json:"firstName"`
-
-	// For only user accounts:
-	LastName string `json:"lastName"`
-	// This has the value true if the user's account has been locked.
-	// If a user tries to log into their account several times and fails, his or her account will be locked for security reasons.
+	// This has the value true if the account has been locked.
+	// An account will be locked for security reasons after too many failed login attempts.
 	IsLocked *bool `json:"isLocked,omitempty"`
-	// True if multi factor authentication is enabled for the user.
+	// True if multi factor authentication is enabled for the account.
 	IsMfaEnabled *bool `json:"isMfaEnabled,omitempty"`
 	// Last login timestamp in UTC in RFC3339 format <date-time> (YYYY-MM-DDTHH:MM:SSZ).
 	LastLoginTimestamp *time.Time `json:"lastLoginTimestamp,omitempty"`

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -115,14 +115,14 @@ func (o *userBuilder) List(ctx context.Context, _ *v2.ResourceId, pToken *pagina
 	accounts, nextPageToken, rateLimit, err := o.service.GetUsers(ctx, parsePageToken(pToken), o.includeServiceAccounts)
 	outputAnnotations.WithRateLimiting(rateLimit)
 	if err != nil {
-		return nil, "", outputAnnotations, fmt.Errorf("failed to get human accounts: %w", err)
+		return nil, "", outputAnnotations, fmt.Errorf("failed to get user accounts: %w", err)
 	}
 
 	// Process accounts
 	for _, account := range accounts {
 		resource, err := createUserResource(account)
 		if err != nil {
-			return nil, "", outputAnnotations, fmt.Errorf("failed to create user resource from human account: %w", err)
+			return nil, "", outputAnnotations, fmt.Errorf("failed to create user resource from user account: %w", err)
 		}
 		resources = append(resources, resource)
 	}
@@ -147,8 +147,8 @@ func newUserBuilder(cclient *client.Client, includeServiceAccounts bool) *userBu
 	}
 }
 
-// createUserResource creates a resource object for either a UserResponse or ServiceAccountResponse.
-func createUserResource(account *client.AccountResponse) (*v2.Resource, error) {
+// createUserResource creates a resource object for either a user or service account.
+func createUserResource(account *client.Account) (*v2.Resource, error) {
 	if account == nil {
 		return nil, fmt.Errorf("account cannot be nil")
 	}
@@ -163,6 +163,12 @@ func createUserResource(account *client.AccountResponse) (*v2.Resource, error) {
 		"modified_by": account.ModifiedBy,
 	}
 
+	// This has the value true if the account has been locked.
+	// An account will be locked for security reasons after too many failed login attempts.
+	if account.IsLocked != nil {
+		profile["is_locked"] = *account.IsLocked
+	}
+
 	// Initialize base user trait options with common fields (email, login, and creation time).
 	userTraitOptions := []rs.UserTraitOption{
 		rs.WithUserLogin(account.Email),
@@ -175,29 +181,23 @@ func createUserResource(account *client.AccountResponse) (*v2.Resource, error) {
 		userTraitOptions = append(userTraitOptions, rs.WithStatus(v2.UserTrait_Status_STATUS_DISABLED))
 	}
 
+	// True if multi factor authentication is enabled for the account.
+	if account.IsMfaEnabled != nil {
+		userTraitOptions = append(userTraitOptions, rs.WithMFAStatus(&v2.UserTrait_MFAStatus{
+			MfaEnabled: *account.IsMfaEnabled,
+		}))
+	}
+
+	// Last login timestamp in UTC in RFC3339 format <date-time> (YYYY-MM-DDTHH:MM:SSZ).
+	if account.LastLoginTimestamp != nil {
+		userTraitOptions = append(userTraitOptions, rs.WithLastLogin(*account.LastLoginTimestamp))
+	}
+
 	// Handle specific account types
 	// User accounts have a firstName and lastName
 	if account.LastName != "" {
 		fullName = account.FirstName + " " + account.LastName
 		profile["full_name"] = fullName
-
-		// This has the value true if the user's account has been locked.
-		// If a user tries to log into their account several times and fails, his or her account will be locked for security reasons.
-		if account.IsLocked != nil {
-			profile["is_locked"] = *account.IsLocked
-		}
-
-		// True if multi factor authentication is enabled for the user.
-		if account.IsMfaEnabled != nil {
-			userTraitOptions = append(userTraitOptions, rs.WithMFAStatus(&v2.UserTrait_MFAStatus{
-				MfaEnabled: *account.IsMfaEnabled,
-			}))
-		}
-
-		// Last login timestamp in UTC in RFC3339 format <date-time> (YYYY-MM-DDTHH:MM:SSZ).
-		if account.LastLoginTimestamp != nil {
-			userTraitOptions = append(userTraitOptions, rs.WithLastLogin(*account.LastLoginTimestamp))
-		}
 
 		userTraitOptions = append(userTraitOptions, rs.WithAccountType(v2.UserTrait_ACCOUNT_TYPE_HUMAN))
 	} else {
@@ -211,7 +211,7 @@ func createUserResource(account *client.AccountResponse) (*v2.Resource, error) {
 
 	// The profile is assigned last because it needs to be built up with account-specific fields
 	// that are only known after determining whether this is a human or service account.
-	// This includes fields like full_name, is_locked, account_type, and other type-specific attributes.
+	// This includes fields like full_name and account_type.
 	userTraitOptions = append(userTraitOptions, rs.WithUserProfile(profile))
 
 	// Create the resource

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -38,7 +38,7 @@ func TestUsersList(t *testing.T) {
 			pageToken *string,
 			includeServiceAccounts bool,
 		) (
-			[]*client.AccountResponse,
+			[]*client.Account,
 			*string,
 			*v2.RateLimitDescription,
 			error,
@@ -75,7 +75,7 @@ func TestUsersList(t *testing.T) {
 			pageToken *string,
 			includeServiceAccounts bool,
 		) (
-			[]*client.AccountResponse,
+			[]*client.Account,
 			*string,
 			*v2.RateLimitDescription,
 			error,
@@ -113,7 +113,7 @@ func TestUsersList(t *testing.T) {
 			pageToken *string,
 			includeServiceAccounts bool,
 		) (
-			[]*client.AccountResponse,
+			[]*client.Account,
 			*string,
 			*v2.RateLimitDescription,
 			error,
@@ -134,7 +134,7 @@ func TestUsersList(t *testing.T) {
 			pageToken *string,
 			includeServiceAccounts bool,
 		) (
-			[]*client.AccountResponse,
+			[]*client.Account,
 			*string,
 			*v2.RateLimitDescription,
 			error,
@@ -146,7 +146,7 @@ func TestUsersList(t *testing.T) {
 			lastLoginTimestamp := time.Now()
 			createdAt := time.Now()
 			modifiedAt := time.Now()
-			users := []*client.AccountResponse{
+			users := []*client.Account{
 				{
 					ID:                 "1",
 					Email:              email,
@@ -188,7 +188,7 @@ func TestUsersList(t *testing.T) {
 			pageToken *string,
 			includeServiceAccounts bool,
 		) (
-			[]*client.AccountResponse,
+			[]*client.Account,
 			*string,
 			*v2.RateLimitDescription,
 			error,
@@ -196,7 +196,7 @@ func TestUsersList(t *testing.T) {
 			isActive := true
 			createdAt := time.Now()
 			modifiedAt := time.Now()
-			accounts := []*client.AccountResponse{
+			accounts := []*client.Account{
 				{
 					ID:         "1",
 					Email:      "baton-service-account@conductorone.com",


### PR DESCRIPTION
#### Description

The `/users` sumo client endpoint offers a bool for also including service accounts in the response. Since this endpoint has pagination and the other `/serviceAccounts` does not, we prefer to consolidate and use pagination across all.

Also consolidates the `AccountResponse` type since now we use one response type instead of two.


#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
