### PR TITLE
[BB-1038] sort /users with service accounts upfront

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -56,7 +56,12 @@ func (c *Client) getUsers(ctx context.Context, pageToken *string, includeService
 	// API Doc: https://api.sumologic.com/docs/#operation/listUsers
 	path := "/api/{{.apiVersion}}/users"
 	pathParameters := map[string]string{"apiVersion": apiVersion}
-	queryParams := map[string]string{"includeServiceAccounts": fmt.Sprintf("%t", includeServiceAccounts)}
+	queryParams := map[string]string{
+		"includeServiceAccounts": fmt.Sprintf("%t", includeServiceAccounts),
+		// Sort by last name in ascending order.
+		// Service accounts have empty strings, so they should be at the beginning.
+		"sortBy": "lastName",
+	}
 
 	var response ApiResponse[Account]
 


### PR DESCRIPTION
#### Description

- sorts the users list so that service accounts come first, making it more similiar to how we used to treat service accounts prior (but we still are using a single, paginated endpoint)



#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
