### PR TITLE
[BB-1038] increase page limit to 1000

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -78,7 +78,7 @@ func (c *Client) getUsers(ctx context.Context, pageToken *string, includeService
 		zap.String("request_url", url.String()),
 		zap.Bool("include_service_accounts", includeServiceAccounts),
 		zap.Int("users_count", len(response.Data)),
-		zap.String("next_page_token", *response.Next),
+		zap.Stringp("next_page_token", response.Next),
 	)
 
 	return response.Data, response.Next, rateLimit, nil

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -7,11 +7,13 @@ import (
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 )
 
 const (
 	apiVersion       = "v1"
-	resourcePageSize = 100 // API: Default value is 100 and the range is 1-100.
+	resourcePageSize = 1000 // API: Default value is 100 and the range is 1-1000.
 )
 
 type Client struct {
@@ -53,6 +55,7 @@ func (c *Client) getUsers(ctx context.Context, pageToken *string, includeService
 	*v2.RateLimitDescription,
 	error,
 ) {
+	l := ctxzap.Extract(ctx)
 	// API Doc: https://api.sumologic.com/docs/#operation/listUsers
 	path := "/api/{{.apiVersion}}/users"
 	pathParameters := map[string]string{"apiVersion": apiVersion}
@@ -70,6 +73,13 @@ func (c *Client) getUsers(ctx context.Context, pageToken *string, includeService
 	if err != nil {
 		return nil, nil, rateLimit, fmt.Errorf("error executing request: %w", err)
 	}
+
+	l.Debug("get-users: results",
+		zap.String("request_url", url.String()),
+		zap.Bool("include_service_accounts", includeServiceAccounts),
+		zap.Int("users_count", len(response.Data)),
+		zap.String("next_page_token", *response.Next),
+	)
 
 	return response.Data, response.Next, rateLimit, nil
 }

--- a/pkg/client/helpers.go
+++ b/pkg/client/helpers.go
@@ -41,7 +41,7 @@ func (c *Client) constructURL(path string, pathParams map[string]string, queryPa
 		q.Set("token", *pageToken)
 	}
 	if pageSize != nil {
-		// API Doc: Default value is 100 and the range is 1-100.
+		// API Doc: Default value is 100 and the range is 1-1000.
 		q.Set("limit", fmt.Sprintf("%d", *pageSize))
 	}
 	// Add any additional query parameters


### PR DESCRIPTION
#### Description

increase page limit to 1000, add debug logs for list users

```
2025-08-05T14:24:05.642-0400	DEBUG	client/client.go:77	get-users: results	{"grpc.start_time": "2025-08-05T14:24:05-04:00", "grpc.service": "c1.connector.v2.ResourcesService", "grpc.method": "ListResources", "peer.address": "127.0.0.1:64756", "request_url": "https://api.sumologic.com/api/v1/users?includeServiceAccounts=true&limit=1000&token=", "include_service_accounts": true, "users_count": 506, "next_page_token": null}
```
